### PR TITLE
Change LED platform from fastled_clockless to esp32_rmt_led_strip

### DIFF
--- a/board_generic_esp32-s3-n16r8.yaml
+++ b/board_generic_esp32-s3-n16r8.yaml
@@ -117,7 +117,7 @@ psram:
 
   
 light:
-  - platform: fastled_clockless
+  - platform: esp32_rmt_led_strip
     rgb_order: GRB
     pin: ${flash_led_pin} #GPIO48
     num_leds: 1


### PR DESCRIPTION
This feature is only available with framework(s) arduino
  Please use 'esp32_rmt_led_strip': https://esphome.io/components/light/esp32_rmt_led_strip.

fix #18