### PR TITLE
fix: resolve Arduino.h macro conflict in rotator.h

### DIFF
--- a/components/esp32_camera_utils/rotator.h
+++ b/components/esp32_camera_utils/rotator.h
@@ -54,14 +54,14 @@ class Rotator {
                                      int& out_w, int& out_h);
 
  private:
-  static constexpr float PI = 3.14159265359f;
-  static constexpr float DEG_TO_RAD = PI / 180.0f;
+  static constexpr float ROTATOR_PI = 3.14159265359f;
+  static constexpr float ROTATOR_DEG_TO_RAD = ROTATOR_PI / 180.0f;
 };
 
 // Implementation moved to header to resolve linker issues
 inline void Rotator::get_rotated_dimensions(int src_w, int src_h, float angle_deg, 
                                      int& out_w, int& out_h) {
-    float angle_rad = angle_deg * DEG_TO_RAD;
+    float angle_rad = angle_deg * ROTATOR_DEG_TO_RAD;
     float cos_a = std::abs(std::cos(angle_rad));
     float sin_a = std::abs(std::sin(angle_rad));
 
@@ -180,7 +180,7 @@ inline bool Rotator::perform_rotation(const uint8_t* input, uint8_t* output,
     }
 
     // Arbitrary rotation (Nearest Neighbor)
-    float angle_rad = rot * DEG_TO_RAD;
+    float angle_rad = rot * ROTATOR_DEG_TO_RAD;
     float cos_a = std::cos(angle_rad);
     float sin_a = std::sin(angle_rad);
 

--- a/components/esp32_camera_utils/rotator.h
+++ b/components/esp32_camera_utils/rotator.h
@@ -8,6 +8,9 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#if __cplusplus >= 202002L
+#include <numbers>
+#endif
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
@@ -54,7 +57,13 @@ class Rotator {
                                      int& out_w, int& out_h);
 
  private:
+  // Use std::numbers::pi_v<float> when available (C++20+), otherwise define our own
+  // This avoids conflicts with Arduino.h macros while being standards-compliant
+#if __cplusplus >= 202002L
+  static constexpr float ROTATOR_PI = std::numbers::pi_v<float>;
+#else
   static constexpr float ROTATOR_PI = 3.14159265359f;
+#endif
   static constexpr float ROTATOR_DEG_TO_RAD = ROTATOR_PI / 180.0f;
 };
 


### PR DESCRIPTION
## Description
Fixes a compilation error caused by macro name conflicts with Arduino.h.

## Problem
Arduino.h defines `PI` and `DEG_TO_RAD` as preprocessor macros. When `rotator.h`
is included in a context where Arduino.h is also included (directly or indirectly),
the macro expansion breaks the C++ syntax:

```cpp
static constexpr float PI = 3.14159265359f;  // Becomes: static constexpr float 3.14159... = 3.14159...
```

This results in:
```
error: expected unqualified-id before numeric constant
#define PI 3.1415926535897932384626433832795
```

## Solution
Rename constants to use component-specific prefixes:
- `PI` → `ROTATOR_PI`
- `DEG_TO_RAD` → `ROTATOR_DEG_TO_RAD`

## Changes
- Modified `components/esp32_camera_utils/rotator.h`
  - Line 57: `static constexpr float PI` → `static constexpr float ROTATOR_PI`
  - Line 58: `static constexpr float DEG_TO_RAD` → `static constexpr float ROTATOR_DEG_TO_RAD`
  - Line 64: Updated usage in `get_rotated_dimensions()`
  - Line 183: Updated usage in `perform_rotation()`

## Testing
- [x] Changes compile without errors
- [x] All references updated consistently
- [x] No functional changes (constants are internal to the class)

## Breaking Changes
None. These are private static constexpr members, not part of the public API.