### PR TITLE
fix PR#100

### DIFF
--- a/components/esp32_camera_utils/rotator.h
+++ b/components/esp32_camera_utils/rotator.h
@@ -8,9 +8,6 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
-#if __cplusplus >= 202002L
-#include <numbers>
-#endif
 #include "esphome/core/log.h"
 #include "esphome/core/hal.h"
 
@@ -57,20 +54,15 @@ class Rotator {
                                      int& out_w, int& out_h);
 
  private:
-  // Use std::numbers::pi_v<float> when available (C++20+), otherwise define our own
-  // This avoids conflicts with Arduino.h macros while being standards-compliant
-#if __cplusplus >= 202002L
-  static constexpr float ROTATOR_PI = std::numbers::pi_v<float>;
-#else
-  static constexpr float ROTATOR_PI = 3.14159265359f;
-#endif
-  static constexpr float ROTATOR_DEG_TO_RAD = ROTATOR_PI / 180.0f;
+  // Use lowercase constants to avoid conflicts with Arduino.h PI and DEG_TO_RAD macros
+  static constexpr float pi = 3.14159265359f;
+  static constexpr float deg_to_rad = pi / 180.0f;
 };
 
 // Implementation moved to header to resolve linker issues
 inline void Rotator::get_rotated_dimensions(int src_w, int src_h, float angle_deg, 
                                      int& out_w, int& out_h) {
-    float angle_rad = angle_deg * ROTATOR_DEG_TO_RAD;
+    float angle_rad = angle_deg * deg_to_rad;
     float cos_a = std::abs(std::cos(angle_rad));
     float sin_a = std::abs(std::sin(angle_rad));
 
@@ -189,7 +181,7 @@ inline bool Rotator::perform_rotation(const uint8_t* input, uint8_t* output,
     }
 
     // Arbitrary rotation (Nearest Neighbor)
-    float angle_rad = rot * ROTATOR_DEG_TO_RAD;
+    float angle_rad = rot * deg_to_rad;
     float cos_a = std::cos(angle_rad);
     float sin_a = std::sin(angle_rad);
 


### PR DESCRIPTION
 Refactor
rotator.h
 to use clean lowercase variable names (pi and deg_to_rad) to avoid Arduino.h macro conflicts, without needing conditional C++20 checks or <numbers>.