### PR TITLE
fix(analog_reader): drop `override` on set_update_interval (non-virtual base — fixes ESPHome 2026.6+ build)

### DIFF
--- a/components/analog_reader/analog_reader.h
+++ b/components/analog_reader/analog_reader.h
@@ -107,7 +107,7 @@ class AnalogReader : public PollingComponent, public esphome::camera::CameraList
       for (auto &dial : dials_) dial.algorithm = algorithm;
   }
   
-  void set_update_interval(uint32_t interval) override;
+  void set_update_interval(uint32_t interval);
 
   void add_dial(DialConfig config) { dials_.push_back(config); }
   


### PR DESCRIPTION
## Problem

Building any `analog_reader`-based config on ESPHome 2026.6.x fails to compile:

```
src/esphome/components/analog_reader/analog_reader.h:110:8: error:
'void esphome::analog_reader::AnalogReader::set_update_interval(uint32_t)'
marked 'override', but does not override
```

ESPHome core's `PollingComponent::set_update_interval(uint32_t)` is a **non-virtual** inline setter (`{ this->update_interval_ = update_interval; }`), so declaring the `AnalogReader` method `override` is illegal under the current core.

## Fix

Drop the `override` specifier on the declaration (one line). Behavior is unchanged — `AnalogReader::set_update_interval` already calls `PollingComponent::set_update_interval(interval)` explicitly (`analog_reader.cpp:115`), then does its extra work. This also brings `analog_reader` in line with `meter_reader_tflite.h:153`, which already declares the same method **without** `override`.

```diff
-  void set_update_interval(uint32_t interval) override;
+  void set_update_interval(uint32_t interval);
```

## Testing

Compiles + links clean on **ESPHome 2026.6.1** (framework: esp-idf, board: esp32cam) — full `[SUCCESS]` build of an `analog_reader` gas-meter config that previously failed only on this error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)